### PR TITLE
feat: Adiciona nova funcionalidade para confirmação de uma medição

### DIFF
--- a/src/controllers/confirm.controller.ts
+++ b/src/controllers/confirm.controller.ts
@@ -1,0 +1,67 @@
+import { PrismaClient } from '@prisma/client';
+import { RequestHandler } from 'express';
+import { confirmSchema } from '../schemas/confirm.schema';
+import { confirmMeasureService } from '../services/confirmMeasure.service';
+import {
+  ConfirmationDuplicateError,
+  InvalidDataError,
+  MeasureNotFoundError,
+} from '../errors';
+
+export const confirmController =
+  (prisma: PrismaClient): RequestHandler =>
+  async (req, res) => {
+    try {
+      // Valida os dados da requisição conforme o schema
+      const parsed = confirmSchema.safeParse(req.body);
+
+      // Se a validação falhar, lança um erro
+      if (!parsed.success) {
+        const errorMessage = parsed.error.errors
+          .map((e) => e.message)
+          .join(', ');
+        throw new InvalidDataError(errorMessage);
+      }
+
+      const { measure_uuid, confirmed_value } = parsed.data;
+
+      // Chama o serviço para confirmar a medição
+      const result = await confirmMeasureService(
+        {
+          measure_uuid,
+          confirmed_value,
+        },
+        prisma
+      );
+
+      // Retorna o resultado da criação da medição
+      res.status(200).json(result);
+    } catch (err: any) {
+      // Erro de dados inválidos
+      if (err instanceof InvalidDataError) {
+        res.status(400).json({
+          error_code: err.code,
+          error_description: err.message,
+        });
+      }
+      // Erro de medição não encontrada pelo uuid
+      else if (err instanceof MeasureNotFoundError) {
+        res.status(404).json({
+          error_code: err.code,
+          error_description: err.message,
+        });
+      }
+      // Erro de tentativa de confirmação já feita
+      else if (err instanceof ConfirmationDuplicateError) {
+        res.status(409).json({
+          error_code: err.code,
+          error_description: err.message,
+        });
+      }
+      // Outros erros internos do servidor
+      else {
+        console.error(err);
+        res.status(500).json({ message: 'Erro interno do servidor' });
+      }
+    }
+  };

--- a/src/controllers/upload.controller.ts
+++ b/src/controllers/upload.controller.ts
@@ -3,7 +3,7 @@ import { RequestHandler } from 'express';
 import { uploadSchema } from '../schemas/upload.schema';
 import { base64Checker } from '../utils/base64Checker.util';
 import { createMeasureService } from '../services/createMeasure.service';
-import { DoubleReportError, InvalidUploadDataError } from '../errors';
+import { DoubleReportError, InvalidDataError } from '../errors';
 
 export const uploadController =
   (prisma: PrismaClient): RequestHandler =>
@@ -17,7 +17,7 @@ export const uploadController =
         const errorMessage = parsed.error.errors
           .map((e) => e.message)
           .join(', ');
-        throw new InvalidUploadDataError(errorMessage);
+        throw new InvalidDataError(errorMessage);
       }
 
       const { customer_code, measure_datetime, measure_type } = parsed.data;
@@ -26,7 +26,7 @@ export const uploadController =
       // Verifica se o arquivo base64 enviado é válido
       const validatedImage = await base64Checker(image);
       if (!validatedImage) {
-        throw new InvalidUploadDataError(
+        throw new InvalidDataError(
           'O arquivo base64 enviado não é um formato suportado para leitura.'
         );
       }
@@ -50,7 +50,7 @@ export const uploadController =
       res.status(200).json(result);
     } catch (err: any) {
       // Erro de dados inválidos no upload
-      if (err instanceof InvalidUploadDataError) {
+      if (err instanceof InvalidDataError) {
         res.status(400).json({
           error_code: err.code,
           error_description: err.message,

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -33,7 +33,7 @@ export class InvalidModelResponseError extends Error {
 // ---------------------- || ---------------------- \\
 
 // Erros para o controller da rota upload
-export class InvalidUploadDataError extends Error {
+export class InvalidDataError extends Error {
   code = 'INVALID_DATA';
   constructor(message?: string) {
     super(message);
@@ -46,6 +46,24 @@ export class DoubleReportError extends Error {
   constructor() {
     super('Leitura do mês já realizada');
     this.name = 'DoubleReportError';
+  }
+}
+// ---------------------- || ---------------------- \\
+
+// Erros para o controller da rota confirm
+export class MeasureNotFoundError extends Error {
+  code = 'MEASURE_NOT_FOUND';
+  constructor() {
+    super('Não existe nenhuma leitura cadastrada com o uuid fornecido');
+    this.name = 'MeasureNotFoundError';
+  }
+}
+
+export class ConfirmationDuplicateError extends Error {
+  code = 'CONFIRMATION_DUPLICATE';
+  constructor() {
+    super('A leitura informada já foi confirmada');
+    this.name = 'MeasureNotFoundError';
   }
 }
 // ---------------------- || ---------------------- \\

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { PrismaClient } from '@prisma/client';
 import express, { Request, Response } from 'express';
-import uploadRoutes from './routes/upload.route';
+import uploadRoute from './routes/upload.route';
+import confirmRoute from './routes/confirm.route';
 import path from 'path';
 
 const app = express();
@@ -14,7 +15,8 @@ app.get('/', (req: Request, res: Response) => {
   res.send('API de Medições Ativa');
 });
 
-app.use(uploadRoutes);
+app.use(uploadRoute);
+app.use(confirmRoute);
 app.use('/uploads', express.static(path.join('/app/uploads')));
 
 // Tratamento de encerramento do servidor

--- a/src/routes/confirm.route.ts
+++ b/src/routes/confirm.route.ts
@@ -1,0 +1,10 @@
+import { PrismaClient } from '@prisma/client';
+import { Router } from 'express';
+import { confirmController } from '../controllers/confirm.controller';
+
+const router = Router();
+const prisma = new PrismaClient();
+
+router.patch('/confirm', confirmController(prisma));
+
+export default router;

--- a/src/schemas/confirm.schema.ts
+++ b/src/schemas/confirm.schema.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+export const confirmSchema = z.object({
+  measure_uuid: z.string().uuid({
+    message: 'O campo measure_uuid exige um UUID válido.',
+  }),
+  confirmed_value: z.preprocess(
+    (val) => {
+      const coerced = Number(val);
+      return Number.isNaN(coerced) ? undefined : coerced;
+    },
+    z.number().int().nonnegative({
+      message: 'O campo confirmed_value deve ser um número inteiro positivo.',
+    }),
+    {
+      required_error: 'O campo confirmed_value é obrigatório.',
+      invalid_type_error:
+        'O campo confirmed_value deve possuir apenas conteúdo numérico.',
+    }
+  ),
+});
+
+export type ConfirmInput = z.infer<typeof confirmSchema>;

--- a/src/services/confirmMeasure.service.ts
+++ b/src/services/confirmMeasure.service.ts
@@ -1,0 +1,40 @@
+import { PrismaClient } from '@prisma/client';
+import { MeasureNotFoundError, ConfirmationDuplicateError } from '../errors';
+
+interface ConfirmMeasureInput {
+  measure_uuid: string;
+  confirmed_value: number;
+}
+
+export const confirmMeasureService = async (
+  data: ConfirmMeasureInput,
+  prisma: PrismaClient
+) => {
+  // Buscar a medição no banco de dados pelo UUID informado
+  const existingMeasure = await prisma.measure.findUnique({
+    where: { id: data.measure_uuid },
+  });
+
+  // Se não existir medição com o UUID fornecido, lançar erro
+  if (!existingMeasure) {
+    throw new MeasureNotFoundError();
+  }
+
+  // Se a medição já tiver sido confirmada anteriormente, lançar erro
+  if (existingMeasure.hasConfirmed) {
+    throw new ConfirmationDuplicateError();
+  }
+
+  // Atualizar a medição com o novo valor confirmado e marcar como confirmada
+  await prisma.measure.update({
+    where: { id: data.measure_uuid },
+    data: {
+      measureValue: data.confirmed_value,
+      hasConfirmed: true,
+    },
+  });
+
+  return {
+    success: true,
+  };
+};


### PR DESCRIPTION
Adiciona os recursos necessários para o funcionamento da rota confirm, incluindo schema, service, controller e a configuração da própria rota.
Adiciona novos erros personalizados.